### PR TITLE
add missing <array> include

### DIFF
--- a/include/ros2_mpu6050/mpu6050.h
+++ b/include/ros2_mpu6050/mpu6050.h
@@ -37,6 +37,7 @@
 #include <string>
 #include <memory>
 #include <cstdint>
+#include <array>
 
 class Mpu6050 {
 public:


### PR DESCRIPTION
This driver doesn't build in recent versions of ROS2 because of this missing include.