### PR TITLE
Add configurable I2C address parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,17 @@ find_package(sensor_msgs REQUIRED)
 include_directories(include)
 
 add_executable(ros2_mpu6050 src/mpu6050.cpp src/mpu6050_hal.cpp src/mpu6050_node.cpp)
-ament_target_dependencies(ros2_mpu6050 rclcpp sensor_msgs)
-target_link_libraries(ros2_mpu6050 i2c)
+target_link_libraries(ros2_mpu6050 PUBLIC
+  ${sensor_msgs_TARGETS}
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
+  i2c
+)
 
 add_executable(ros2_mpu6050_calibrate src/mpu6050.cpp src/mpu6050_hal.cpp src/mpu6050_calibrate.cpp)
-ament_target_dependencies(ros2_mpu6050_calibrate)
-target_link_libraries(ros2_mpu6050_calibrate i2c)
+target_link_libraries(ros2_mpu6050_calibrate PUBLIC
+  i2c
+)
 
 install(
   DIRECTORY include

--- a/include/ros2_mpu6050/mpu6050.h
+++ b/include/ros2_mpu6050/mpu6050.h
@@ -34,6 +34,7 @@
 
 #include "ros2_mpu6050/mpu6050_hal.h"
 
+#include <array>
 #include <string>
 #include <memory>
 #include <cstdint>

--- a/launch/ros2_mpu6050.launch.py
+++ b/launch/ros2_mpu6050.launch.py
@@ -10,10 +10,15 @@ def generate_launch_description():
     share_dir = get_package_share_directory('ros2_mpu6050')
 
     param_file = LaunchConfiguration('param_file')
+    i2c_address = LaunchConfiguration('i2c_address')
 
     params_arg = DeclareLaunchArgument('param_file',
                                         default_value=os.path.join(share_dir, 'config', 'params.yaml'),
                                         description='Path to the ROS2 parameter file')
+
+    i2c_address_arg = DeclareLaunchArgument('i2c_address',
+                                             default_value='104',
+                                             description='I2C address of the MPU6050 (104=0x68 when AD0 low, 105=0x69 when AD0 high)')
 
     mpu6050_sensor = Node(
         package='ros2_mpu6050',
@@ -21,10 +26,12 @@ def generate_launch_description():
         name='mpu6050_sensor',
         output="screen",
         emulate_tty=True,
-        parameters=[param_file]
+        parameters=[param_file,
+                    {'i2c_address': i2c_address}]
     )
 
     return LaunchDescription([
         params_arg,
+        i2c_address_arg,
         mpu6050_sensor
     ])

--- a/src/mpu6050_node.cpp
+++ b/src/mpu6050_node.cpp
@@ -7,9 +7,9 @@ using namespace std::chrono_literals;
 
 Mpu6050Node::Mpu6050Node(const std::string& name)
     : Node(name)
-    , mpu6050_dev_{std::make_unique<Mpu6050>()}
 {
     // Declare parameters
+    this->declare_parameter<int>("i2c_address", 0x68);
     this->declare_parameter<int>("gyro_fs_sel", 0);
     this->declare_parameter<int>("accel_afs_sel", 0);
     this->declare_parameter<int>("dlpf_cfg", 0);
@@ -21,6 +21,11 @@ Mpu6050Node::Mpu6050Node(const std::string& name)
     this->declare_parameter<double>("accel_y_offset", 0.0);
     this->declare_parameter<double>("accel_z_offset", 0.0);
 
+    /* Initialize MPU6050 device with I2C parameters */
+    int i2c_address = this->get_parameter("i2c_address").as_int();
+    mpu6050_dev_ = std::make_unique<Mpu6050>("/dev/i2c-1", i2c_address);
+
+    RCLCPP_INFO(this->get_logger(), "MPU6050 initialized at address 0x%02X", i2c_address);
     /* Assign offset values */
     gyro_x_offset_ = this->get_parameter("gyro_x_offset").as_double();
     gyro_y_offset_ = this->get_parameter("gyro_y_offset").as_double();


### PR DESCRIPTION
This PR makes the I2C address configurable via ROS 2 launch arguments

## Changes
- Added `i2c_address` parameter (default: `0x68`)
- Updated launch file with corresponding launch arguments
- Added missing `<array>` include to fix build error with GCC 13

## Usage
```bash
# Default (address 0x68)
ros2 launch ros2_mpu6050 ros2_mpu6050.launch.py

# Custom address (0x69 when AD0 pin is high)
ros2 launch ros2_mpu6050 ros2_mpu6050.launch.py i2c_address:=105